### PR TITLE
Remove unnecessary Promise wrapper

### DIFF
--- a/src/js/services/http.js
+++ b/src/js/services/http.js
@@ -7,9 +7,7 @@ const http = {
    * @return {Object} Promise
    */
   get(url) {
-    return new Promise((resolve) => {
-      fetch(url).then(res => resolve(res.json()))
-    })
+    return  fetch(url).then(res => res.json())
   },
 }
 


### PR DESCRIPTION
We can just call `fetch().then` instead of wrapping it inside of a `Promise` value since `fetch().then()` will return a Promise.